### PR TITLE
fix: Correct the object name for has_changed handler, group logic

### DIFF
--- a/dynamodb_stream_router/conditions/parser.py
+++ b/dynamodb_stream_router/conditions/parser.py
@@ -274,13 +274,19 @@ class ExpressionParser(Parser):
         def has_changed(record, keys=key_list):
             for k in keys:
                 if (
-                    k not in record.old_image
-                    and k in self.new_image
-                    or k not in record.old_image
-                    and k in record.new_image
-                    or k in record.new_image
-                    and k in record.old_image
-                    and record.old_image[k] != record.new_image[k]
+                    (
+                        k not in record.old_image
+                        and k in record.new_image
+                    )
+                    or (
+                        k not in record.old_image
+                        and k in record.new_image
+                    )
+                    or (
+                        k in record.new_image
+                        and k in record.old_image
+                        and record.old_image[k] != record.new_image[k]
+                    )
                 ):
                     return True
 


### PR DESCRIPTION
I ran into a bug while using this library, looked like something was missed during a refactor. 

This PR corrects the object in the has_changed handler and groups the logic statements for clarity.